### PR TITLE
Add failOk to WorkerJob to avoid printing failure messages for failed jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log for `process_runner`
 
+## 2.0.5
+
+* Added `WorkerJob.failOk` so that failure message of failed worker jobs is
+  suppressed by default, but can be turned on.
+
 ## 2.0.4
 
 * Added `printOutputDefault` to the `ProcessRunner` constructor, and updated

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 2.0.4
+version: 2.0.5
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 


### PR DESCRIPTION
Added `WorkerJob.failOk` so that failure message of failed worker jobs is suppressed by default, but can be turned on.