### PR TITLE
expand the sdk constraint to <2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for `process_runner`
 
+## 4.0.0-nullsafety.1
+
+* Expand the sdk constraint to `<2.11.0`.
+
 ## 4.0.0-nullsafety
 
 * Convert to non-nullable by default, enable null-safety experiment for Dart.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.0.0-nullsafety
+version: 4.0.0-nullsafety.1
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 
@@ -19,4 +19,4 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.1
 
 environment:
-  sdk: '>=2.10.0-4.0.dev <2.10.0'
+  sdk: '>=2.10.0-4.0.dev <2.11.0'


### PR DESCRIPTION
This is needed for flutter so that the Dart sdk version can bump to 2.11.