### PR TITLE
Added exception to WorkerJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log for `process_runner`
 
+## 3.1.0
+
+* Add `exception` to the `WorkerJob` so that when commands fail to run, the
+  exception output can be seen.
+* Fixed a problem with the default output function where it didn't count
+  failed jobs as finished.
+* Removed dependency on mockito and args to match nullsafety version.
+
 ## 3.0.0
 
 * Breaking change to change the `result` given in the `ProcessRunnerException`

--- a/example/main.dart
+++ b/example/main.dart
@@ -11,7 +11,6 @@
 
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:process_runner/process_runner.dart';
 
 // This only works for escaped spaces and things in double or single quotes.
@@ -76,55 +75,70 @@ List<String> splitIntoArgs(String args) {
   return result;
 }
 
-Future<void> main(List<String> args) async {
-  final ArgParser parser = ArgParser();
-  parser.addFlag('help', help: 'Print help.');
-  parser.addFlag('report', help: 'Print progress on the jobs while running.', defaultsTo: false);
-  parser.addOption('workers',
-      abbr: 'w',
-      help: 'Specify the number of workers jobs to run simultanously. Defaults '
-          'to the number of processors on the machine.');
-  parser.addOption('workingDirectory',
-      abbr: 'd', help: 'Specify the working directory to run on', defaultsTo: '.');
-  parser.addMultiOption('cmd',
-      abbr: 'c',
-      help: 'Specify a command to add to the commands to be run. Entire '
-          'command must be quoted by the shell. Commands specified with this '
-          'option run before those specified with --cmdFile');
-  parser.addOption('file',
-      abbr: 'f',
-      help: 'Specify the name of a file to read commands from, one per line, as '
-          'they would appear on the command line, with spaces escaped or '
-          'quoted. Specify "-" to read from stdin.',
-      defaultsTo: '-');
-  final ArgResults options = parser.parse(args);
+String usage() {
+  return '''
+main.dart [flags]
+    --[no-]help           Print help.
+    --[no-]report         Print progress on the jobs while running.
+-w, --workers             Specify the number of workers jobs to run simultanously. Defaults to the number of processors on the machine.
+-d, --workingDirectory    Specify the working directory to run on
+                          (defaults to ".")
+-c, --cmd                 Specify a command to add to the commands to be run. Entire command must be quoted by the shell. Commands specified with this option run before those specified with --cmdFile
+-f, --file                Specify the name of a file to read commands from, one per line, as they would appear on the command line, with spaces escaped or quoted. Specify "-" to read from stdin.
+                          (defaults to "-")
+''';
+}
 
-  if (options['help'] as bool) {
+String findOption(String option, List<String> args) {
+  for (int i = 0; i < args.length - 1; ++i) {
+    if (args[i] == option) {
+      return args[i + 1];
+    }
+  }
+  return null;
+}
+
+Iterable<String> findAllOptions(String option, List<String> args) sync* {
+  for (int i = 0; i < args.length - 1; ++i) {
+    if (args[i] == option) {
+      yield args[i + 1];
+    }
+  }
+}
+
+Future<void> main(List<String> args) async {
+  // Parse args without ArgParser until ArgParser is null-safe.
+  if (args.contains('--help')) {
     print('main.dart [flags]');
-    print(parser.usage);
+    print(usage());
     exit(0);
   }
 
+  final bool printReport = args.contains('--report');
+  // If the numWorkers is set to null, then the ProcessPool will automatically
+  // select the number of processes based on how many CPU cores the machine has.
+  final int numWorkers = int.tryParse(findOption('workers', args) ?? '');
+  final Directory workingDirectory = Directory(findOption('workingDirectory', args) ?? '.');
+  final List<String> cmds = findAllOptions('cmd', args).toList();
+
   // Collect the commands to be run from the command file.
-  final String commandFile = options['file'] as String;
+  final String commandFile = findOption('file', args) ?? '-';
   List<String> fileCommands = <String>[];
-  if (commandFile != null) {
-    // Read from stdin if the --file option is set to '-'.
-    if (commandFile == '-') {
-      String line = stdin.readLineSync();
-      while (line != null) {
-        fileCommands.add(line);
-        line = stdin.readLineSync();
-      }
-    } else {
-      // Read the commands from a file.
-      final File cmdFile = File(commandFile);
-      if (!cmdFile.existsSync()) {
-        print('Command file "$commandFile" doesn\'t exist.');
-        exit(1);
-      }
-      fileCommands = cmdFile.readAsLinesSync();
+  // Read from stdin if the --file option is set to '-'.
+  if (commandFile == '-') {
+    String line = stdin.readLineSync();
+    while (line != null) {
+      fileCommands.add(line);
+      line = stdin.readLineSync();
     }
+  } else {
+    // Read the commands from a file.
+    final File cmdFile = File(commandFile);
+    if (!cmdFile.existsSync()) {
+      print('Command file "$commandFile" doesn\'t exist.');
+      exit(1);
+    }
+    fileCommands = cmdFile.readAsLinesSync();
   }
 
   // Collect all the commands, both from the input file, and from the command
@@ -132,21 +146,13 @@ Future<void> main(List<String> args) async {
   // executed simultaneously, depending on the number of workers, and number of
   // commands).
   final List<String> commands = <String>[
-    ...options['cmd'] as List<String>,
+    ...cmds,
     ...fileCommands,
   ];
 
   // Split each command entry into a list of strings, taking into account some
   // simple quoting and escaping.
   final List<List<String>> splitCommands = commands.map<List<String>>(splitIntoArgs).toList();
-
-  // If the numWorkers is set to null, then the ProcessPool will automatically
-  // select the number of processes based on how many CPU cores the machine has.
-  final int numWorkers = int.tryParse(options['workers'] as String ?? '');
-
-  final bool printReport = (options['report'] as bool) ?? false;
-
-  final Directory workingDirectory = Directory((options['workingDirectory'] as String) ?? '.');
 
   final ProcessPool pool = ProcessPool(
     numWorkers: numWorkers,
@@ -159,5 +165,6 @@ Future<void> main(List<String> args) async {
     if (printReport) {
       print('\nFinished job ${done.name}');
     }
+    stdout.write(done.result.stdout);
   }
 }

--- a/lib/src/process_runner.dart
+++ b/lib/src/process_runner.dart
@@ -5,7 +5,7 @@
 import 'dart:async' show Completer;
 import 'dart:convert' show Encoding;
 import 'dart:io'
-    show Process, ProcessResult, ProcessException, Directory, stderr, stdout, SystemEncoding
+    show Process, ProcessException, Directory, stderr, stdout, SystemEncoding
     hide Platform;
 
 import 'package:platform/platform.dart' show Platform, LocalPlatform;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 3.0.0
+version: 3.1.0
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -65,5 +65,22 @@ void main() {
       expect(completed.first.result.stderr, equals('stderr1'));
       expect(completed.first.result.output, equals('output1stderr1'));
     });
+    test('Commands the throw exceptions report results', () async {
+      fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+      processRunner = ProcessRunner(processManager: fakeProcessManager);
+      processPool = ProcessPool(processRunner: processRunner, printReport: null);
+      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
+        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+          ProcessResult(0, -1, 'output1', 'stderr1'),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      final List<WorkerJob> jobs = <WorkerJob>[
+        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+      ];
+      final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+      expect(completed.first.result, isNull);
+      expect(completed.first.exception, isNotNull);
+    });
   });
 }


### PR DESCRIPTION
This adds an `exception` field to the `WorkerJob` class, so that if a job throws an exception, it can be accessed.

It also brings the code in line with the nullsafety version, removing dependencies on the `mockito` and `args` packages.