### PR TITLE
Revert change to job working directory behavior

### DIFF
--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -18,14 +18,13 @@ class WorkerJob {
   WorkerJob(
     this.command, {
     String name,
-    Directory workingDirectory,
+    this.workingDirectory,
     this.printOutput = false,
     this.stdin,
     this.stdinRaw,
     this.failOk = true,
   })  : assert(failOk != null),
         assert(printOutput != null),
-        workingDirectory = workingDirectory ?? Directory.current,
         name = name ?? command.join(' ');
 
   /// The name of the job.
@@ -169,7 +168,8 @@ class ProcessPool {
     int pending,
     int failed,
   ) {
-    final String percent = total == 0 ? '100' : ((100 * (completed + failed)) ~/ total).toString().padLeft(3);
+    final String percent =
+        total == 0 ? '100' : ((100 * (completed + failed)) ~/ total).toString().padLeft(3);
     final String completedStr = completed.toString().padLeft(3);
     final String totalStr = total.toString().padRight(3);
     final String inProgressStr = inProgress.toString().padLeft(2);
@@ -185,7 +185,7 @@ class ProcessPool {
       job.result = null;
       job.result = await processRunner.runProcess(
         job.command,
-        workingDirectory: job.workingDirectory,
+        workingDirectory: job.workingDirectory ?? processRunner.defaultWorkingDirectory,
         printOutput: job.printOutput,
         stdin: job.stdinRaw ?? encoding.encoder.bind(job.stdin ?? const Stream<String>.empty()),
         failOk: false, // Must be false so that we can catch the exception below.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,16 +8,16 @@ description: A process invocation astraction for Dart that manages a multiproces
 homepage: https://github.com/google/process_runner
 
 dependencies:
+  async: ^2.4.2
   file: ^5.0.0
   meta: ^1.1.2
   path: ^1.5.1
   platform: ^2.2.0
   process: ^3.0.13
-  async: ^2.4.2
 
 dev_dependencies:
-  test: ^1.0.0
   mockito: ^4.1.1
+  test: ^1.0.0
 
 environment:
   sdk: '>=2.3.0 <3.0.0'

--- a/test/src/fake_process_manager_test.dart
+++ b/test/src/fake_process_manager_test.dart
@@ -28,17 +28,18 @@ void main() {
     tearDown(() async {});
 
     test('start works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
-        <String>['command2', 'arg1', 'arg2']: <ProcessResult>[
+        FakeInvocationRecord(<String>['command2', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output2', ''),
         ],
       };
       processManager.fakeResults = calls;
-      for (final List<String> key in calls.keys) {
-        final Process process = await processManager.start(key);
+      for (final FakeInvocationRecord key in calls.keys) {
+        final Process process = await processManager.start(key.invocation);
         String output = '';
         process.stdout.listen((List<int> item) {
           output += utf8.decode(item);
@@ -50,51 +51,54 @@ void main() {
     });
 
     test('run works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
-        <String>['command2', 'arg1', 'arg2']: <ProcessResult>[
+        FakeInvocationRecord(<String>['command2', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output2', ''),
         ],
       };
       processManager.fakeResults = calls;
-      for (final List<String> key in calls.keys) {
-        final ProcessResult result = await processManager.run(key);
+      for (final FakeInvocationRecord key in calls.keys) {
+        final ProcessResult result = await processManager.run(key.invocation);
         expect(result.stdout, equals((calls[key] ?? <ProcessResult>[])[0].stdout));
       }
       processManager.verifyCalls(calls.keys.toList());
     });
 
     test('runSync works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
-        <String>['command2', 'arg1', 'arg2']: <ProcessResult>[
+        FakeInvocationRecord(<String>['command2', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output2', ''),
         ],
       };
       processManager.fakeResults = calls;
-      for (final List<String> key in calls.keys) {
-        final ProcessResult result = processManager.runSync(key);
+      for (final FakeInvocationRecord key in calls.keys) {
+        final ProcessResult result = processManager.runSync(key.invocation);
         expect(result.stdout, equals((calls[key] ?? <ProcessResult>[])[0].stdout));
       }
       processManager.verifyCalls(calls.keys.toList());
     });
 
     test('captures stdin', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
-        <String>['command2', 'arg1', 'arg2']: <ProcessResult>[
+        FakeInvocationRecord(<String>['command2', 'arg1', 'arg2']): <ProcessResult>[
           ProcessResult(0, 0, 'output2', ''),
         ],
       };
       processManager.fakeResults = calls;
-      for (final List<String> key in calls.keys) {
-        final Process process = await processManager.start(key);
+      for (final FakeInvocationRecord key in calls.keys) {
+        final Process process = await processManager.start(key.invocation);
         String output = '';
         process.stdout.listen((List<int> item) {
           output += utf8.decode(item);

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -10,22 +10,26 @@ import 'package:process_runner/process_runner.dart';
 import 'fake_process_manager.dart';
 
 void main() {
-  FakeProcessManager fakeProcessManager = FakeProcessManager((String value) {});
-  ProcessRunner processRunner = ProcessRunner(processManager: fakeProcessManager);
-  ProcessPool processPool = ProcessPool(processRunner: processRunner);
+  FakeProcessManager fakeProcessManager;
+  ProcessRunner processRunner;
+  ProcessPool processPool;
 
   setUp(() {
     fakeProcessManager = FakeProcessManager((String value) {});
-    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processRunner = ProcessRunner(
+      processManager: fakeProcessManager,
+      defaultWorkingDirectory: Directory('/tmp/foo'),
+    );
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
   });
 
   tearDown(() {});
 
-  group('Ouput Capture', () {
+  group('Output Capture', () {
     test('startWorkers works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
       };
@@ -37,8 +41,9 @@ void main() {
       fakeProcessManager.verifyCalls(calls.keys);
     });
     test('runToCompletion works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
       };
@@ -50,8 +55,9 @@ void main() {
       fakeProcessManager.verifyCalls(calls.keys);
     });
     test('failed tests report results', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };
@@ -69,8 +75,9 @@ void main() {
       fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
       processRunner = ProcessRunner(processManager: fakeProcessManager);
       processPool = ProcessPool(processRunner: processRunner, printReport: null);
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };

--- a/test/src/process_runner_test.dart
+++ b/test/src/process_runner_test.dart
@@ -16,53 +16,60 @@ void main() {
 
   setUp(() {
     fakeProcessManager = FakeProcessManager((String value) {});
-    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processRunner = ProcessRunner(
+        processManager: fakeProcessManager, defaultWorkingDirectory: Directory('/tmp/foo'));
   });
 
   tearDown(() {});
 
   group('Ouput Capture', () {
     test('runProcess works', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
       };
       fakeProcessManager.fakeResults = calls;
-      await processRunner.runProcess(calls.keys.first);
+      await processRunner.runProcess(calls.keys.first.invocation);
       fakeProcessManager.verifyCalls(calls.keys);
     });
     test('runProcess returns correct output', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, 0, 'output1', 'stderr1'),
         ],
       };
       fakeProcessManager.fakeResults = calls;
-      final ProcessRunnerResult result = await processRunner.runProcess(calls.keys.first);
+      final ProcessRunnerResult result =
+          await processRunner.runProcess(calls.keys.first.invocation);
       fakeProcessManager.verifyCalls(calls.keys);
       expect(result.stdout, equals('output1'));
       expect(result.stderr, equals('stderr1'));
       expect(result.output, equals('output1stderr1'));
     });
     test('runProcess fails properly', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], ''): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };
       fakeProcessManager.fakeResults = calls;
-      await expectLater(() => processRunner.runProcess(calls.keys.first), throwsException);
+      await expectLater(
+          () => processRunner.runProcess(calls.keys.first.invocation), throwsException);
     });
     test('runProcess returns the failed results properly', () async {
-      final Map<List<String>, List<ProcessResult>> calls = <List<String>, List<ProcessResult>>{
-        <String>['command', 'arg1', 'arg2']: <ProcessResult>[
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], '/tmp/foo'): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };
       fakeProcessManager.fakeResults = calls;
       final ProcessRunnerResult result =
-          await processRunner.runProcess(calls.keys.first, failOk: true);
+          await processRunner.runProcess(calls.keys.first.invocation, failOk: true);
       expect(result.stdout, equals('output1'));
       expect(result.stderr, equals('stderr1'));
       expect(result.output, equals('output1stderr1'));


### PR DESCRIPTION
The migration of the null safety changes to the master branch caused an inadvertent behavior change, which this change reverts and adds testing for (working directory is not tested in each test).

Also updates the testing framework to include working directory in the invocation record.