### PR TITLE
Add process runner utility, update example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log for `process_runner`
 
+## 4.1.0
+
+* Adds a pub-installable command line utility, based on the example code, to run a tasks queue of commands from a command line. See [README.md](README.md) for more details.
+* Example code is updated.
+* Now throws a `ProcessRunnerException` if a job fails and `failOk` on that job is `false`.
+
 ## 4.0.1
 
 * Add startMode to allow passing of a ProcessStartMode to

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ it allows creation of a pool of worker processes with [`ProcessPool`], and
 manages running them with a set number of active [`WorkerJob`s], and manages the
 collection of their stdout, stderr, and interleaved stdout and stderr output.
 
-See the [example](example/main.dart) and [`process_runner` library] docs for
+See the [example](example/main.dart) and [`process_runner` library docs] for
 more information on how to use it, but the basic usage for  is:
 
 ```dart
@@ -71,11 +71,79 @@ Future<void> main() async {
 }
 ```
 
+## `process_runner` utility
+
+The example can also be installed and run as a useful command-line utility. You can install it using:
+
+```shell
+dart pub global activate process_runner
+```
+
+And you can run it with:
+
+```shell
+dart pub global run process_runner
+```
+
+The above steps will work on any Dart-supported platform.
+
+Of course, you can also just compile the example into a native executable and move it to a directory in your PATH:
+
+```shell
+dart compile exe bin/process_runner.dart -o process_runner
+mv process_runner /some/bin/dir/in/your/path
+```
+
+The usage for the utility is as follows:
+
+```
+process_runner [--help] [--quiet] [--report] [--stdout] [--stderr]
+               [--run-in-shell] [--working-directory=<working directory>]
+               [--jobs=<num_worker_jobs>] [--command="command" ...]
+               [--source=<file|"-"> ...]:
+-h, --help                 Print help for process_runner.
+-q, --quiet                Silences the stderr and stdout output of the
+                           commands. This is a shorthand for "--no-stdout
+                           --no-stderr".
+-r, --report               Print progress on the jobs to stderr while running.
+    --[no-]stdout          Prints the stdout output of the commands to stdout in
+                           the order they complete. Will not interleave lines
+                           from separate processes. Has no effect if --quiet is
+                           specified.
+                           (defaults to on)
+    --[no-]stderr          Prints the stderr output of the commands to stderr in
+                           the order they complete. Will not interleave lines
+                           from separate processes. Has no effect if --quiet is
+                           specified
+                           (defaults to on)
+    --run-in-shell         Run the commands in a subshell.
+    --[no-]fail-ok         If set, allows continuing execution of the remaining
+                           commands even if one fails to execute. If not set,
+                           ("--no-fail-ok") then process will just exit with a
+                           non-zero code at completion if there were any jobs
+                           that failed.
+-j, --jobs                 Specify the number of worker jobs to run
+                           simultaneously. Defaults to the number of processor
+                           cores on the machine.
+    --working-directory    Specify the working directory to run in.
+                           (defaults to ".")
+-c, --command              Specify a command to add to the commands to be run.
+                           Commands specified with this option run before those
+                           specified with --source. Be sure to quote arguments
+                           to --command properly on the command line.
+-s, --source               Specify the name of a file to read commands from, one
+                           per line, as they would appear on the command line,
+                           with spaces escaped or quoted. Specify "--source -"
+                           to read from stdin. More than one --source argument
+                           may be specified, and they will be concatenated in
+                           the order specified. The stdin ("--source -")
+                           argument may only be specified once.
+```
 
 [`ProcessManager`]: https://github.com/google/process.dart/blob/master/lib/src/interface/process_manager.dart#L21
 [`process`]: https://pub.dev/packages/process
 [`process_runner`]: https://pub.dev/packages/process_runner
 [`ProcessRunner`]: https://pub.dev/documentation/process_runner/latest/process_runner/ProcessRunner-class.html
 [`ProcessPool`]: https://pub.dev/documentation/process_runner/latest/process_runner/ProcessPool-class.html
-[`process_runner` library]: https://pub.dev/documentation/process_runner/latest/process_runner/process_runner-library.html
+[`process_runner` library docs]: https://pub.dev/documentation/process_runner/latest/process_runner/process_runner-library.html
 [`WorkerJob`s]: https://pub.dev/documentation/process_runner/latest/process_runner/WorkerJob-class.html

--- a/bin/process_runner.dart
+++ b/bin/process_runner.dart
@@ -1,0 +1,18 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This utility sends a bunch of jobs to a ProcessPool for processing.
+//
+// It can speed up processing of a bunch of single-threaded CPU-intensive
+// commands by a multiple of the number of processor cores you have (modulo being
+// disk/network bound, of course).
+//
+// You can install this command with "dart pub global activate process_runner",
+// and you can run it with "dart pub global run process_runner".
+
+import '../example/main.dart' as runner_main;
+
+Future<void> main(List<String> args) async {
+  return runner_main.main(args);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.0.1
+version: 4.1.0
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 
@@ -20,3 +20,6 @@ dev_dependencies:
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+
+binaries:
+  process_runner:

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -72,7 +72,22 @@ void main() {
       expect(completed.first.result.stderr, equals('stderr1'));
       expect(completed.first.result.output, equals('output1stderr1'));
     });
-    test('Commands the throw exceptions report results', () async {
+    test('failed tests throw when failOk is false', () async {
+      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+          <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+          ProcessResult(0, -1, 'output1', 'stderr1'),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      final List<WorkerJob> jobs = <WorkerJob>[
+        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1', failOk: false),
+      ];
+      expect(() async {
+        await processPool.runToCompletion(jobs);
+      }, throwsException);
+    });
+    test('Commands that throw exceptions report results', () async {
       fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
       processRunner = ProcessRunner(processManager: fakeProcessManager);
       processPool = ProcessPool(processRunner: processRunner, printReport: null);


### PR DESCRIPTION
## Description

* Adds a pub-installable command line utility, based on the example code, to run a tasks queue of commands from a command line. See README.md for more details.
* Example code is updated.
* Now throws a `ProcessRunnerException` if a job fails and `failOk` on that job is `false`.