### PR TITLE
Add missing dependency on args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for `process_runner`
 
+## 4.1.1
+
+* Adds missing dependency on args package to allow global activate.
+
 ## 4.1.0
 
 * Adds a pub-installable command line utility, based on the example code, to run a tasks queue of commands from a command line. See [README.md](README.md) for more details.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: https://github.com/google/process_runner/example
 publish_to: none
 
 dependencies:
-  args: ^2.1.0
+  args: ^2.3.0
   process_runner:
     path: ..
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,12 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.0
+version: 4.1.1
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 
 dependencies:
+  args: ^2.3.0
   async: ^2.5.0
   file: ^6.1.0
   meta: ^1.3.0


### PR DESCRIPTION
I missed a dependency on the args package that prevents global activation of the binary.