### PR TITLE
Bump platform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.1.2
 
+* Bump dependency version for platform package so process_runner works with newer versions of dart:io.
+
+## 4.1.2
+
 * Reduces process pool output in "report" mode by not printing individual completions.
 
 ## 4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.2
+version: 4.1.3
 description: A process invocation astraction for Dart that manages a multiprocess queue.
 homepage: https://github.com/google/process_runner
 
@@ -13,7 +13,7 @@ dependencies:
   file: ^6.1.0
   meta: ^1.3.0
   path: ^1.8.0
-  platform: ^3.0.0
+  platform: ^3.1.0
   process: ^4.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Bumps the required version of the `platform` package to 3.1.0, so that it avoids an API deprecated in recent versions of dart:io.