### PR TITLE
Add `WorkerTaskGroup` for serial tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log for `process_runner`
 
-## 4.1.5
+## 5.0.0
 
-* Added WorkerTaskGroup for running a group of dependent tasks in order.
+* Added `WorkerTaskGroup` for running a group of dependent tasks in order.
+* Adds pending jobs to progress reporting callback API, causing a breaking change to the `ProcessPool` API.
 
 ## 4.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for `process_runner`
 
+## 4.1.5
+
+* Added WorkerTaskGroup for running a group of dependent tasks in order.
+
 ## 4.1.4
 
 * Bump dependency version for `process`.
@@ -40,11 +44,11 @@
 
 ## 4.0.0-nullsafety.3
 
-* Rebase onto non-nullsafety version 3.1.1 to pick up those changes. 
+* Rebase onto non-nullsafety version 3.1.1 to pick up those changes.
 
 ## 4.0.0-nullsafety.2
 
-* Rebase onto non-nullsafety version 3.1.0 to pick up those changes. 
+* Rebase onto non-nullsafety version 3.1.0 to pick up those changes.
 
 ## 4.0.0-nullsafety.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -81,7 +81,6 @@ linter:
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
     - cast_nullable_to_non_nullable
-    - collection_methods_unrelated_type
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204

--- a/example/main.dart
+++ b/example/main.dart
@@ -123,7 +123,8 @@ void stderrPrintReport(
   int groupsPending,
   int failed,
 ) {
-  stderr.write(ProcessPool.defaultReportToString(total, completed, inProgress, pending, groupsPending, failed));
+  stderr.write(ProcessPool.defaultReportToString(
+      total, completed, inProgress, pending, groupsPending, failed));
 }
 
 Future<void> main(List<String> args) async {
@@ -286,20 +287,23 @@ Future<void> main(List<String> args) async {
   // Split each command entry into a list of strings, taking into account some
   // simple quoting and escaping.
   final List<List<List<String>>> splitCommands = commandGroups
-      .map<List<List<String>>>((List<String> group) => group.map<List<String>>(splitIntoArgs).toList())
+      .map<List<List<String>>>(
+          (List<String> group) => group.map<List<String>>(splitIntoArgs).toList())
       .toList();
 
   // If the numWorkers is set to null, then the ProcessPool will automatically
   // select the number of processes based on how many CPU cores the machine has.
   final int? numWorkers = int.tryParse(options[_kJobsOption] as String? ?? '');
-  final Directory workingDirectory = Directory((options[_kWorkingDirectoryOption] as String?) ?? '.');
+  final Directory workingDirectory =
+      Directory((options[_kWorkingDirectoryOption] as String?) ?? '.');
 
   final ProcessPool pool = ProcessPool(
     numWorkers: numWorkers,
     printReport: printReport ? stderrPrintReport : null,
   );
-  final Iterable<WorkerTaskGroup> jobs = splitCommands.map<WorkerTaskGroup>((List<List<String>> group) {
-    return WorkerTaskGroup(group
+  final Iterable<WorkerJobGroup> jobs =
+      splitCommands.map<WorkerJobGroup>((List<List<String>> group) {
+    return WorkerJobGroup(group
         .map<WorkerJob>((List<String> command) => WorkerJob(
               command,
               workingDirectory: workingDirectory,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,11 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.5
+description: A process invocation abstraction for Dart that manages a multi-process queue.
+version: 5.0.0
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
-description: A process invocation abstraction for Dart that manages a multi-process queue.
 homepage: https://github.com/google/process_runner
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,11 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.4
-description: A process invocation astraction for Dart that manages a multiprocess queue.
+version: 4.1.5
+repository: https://github.com/google/process_runner
+issue_tracker: https://github.com/google/process_runner/issues
+documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
+description: A process invocation abstraction for Dart that manages a multi-process queue.
 homepage: https://github.com/google/process_runner
 
 dependencies:

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -25,7 +25,8 @@ void main() {
   });
 
   test('startWorkers works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -38,7 +39,8 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('runToCompletion works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -51,7 +53,8 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('failed tests report results', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -67,7 +70,8 @@ void main() {
     expect(completed.first.result.output, equals('output1stderr1'));
   });
   test('failed tests throw when failOk is false', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -84,7 +88,8 @@ void main() {
     fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -102,7 +107,8 @@ void main() {
     fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['commandA1', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -124,14 +130,14 @@ void main() {
     };
     fakeProcessManager.fakeResults = calls;
     final List<Job> jobs = <Job>[
-      WorkerTaskGroup(
+      WorkerJobGroup(
         <WorkerJob>[
           WorkerJob(<String>['commandA1', 'arg1', 'arg2'], name: 'job A1'),
           WorkerJob(<String>['commandA2', 'arg1', 'arg2'], name: 'job A2'),
           WorkerJob(<String>['commandA3', 'arg1', 'arg2'], name: 'job A3'),
         ],
       ),
-      WorkerTaskGroup(
+      WorkerJobGroup(
         <WorkerJob>[
           WorkerJob(<String>['commandB1', 'arg1', 'arg2'], name: 'job B1'),
           WorkerJob(<String>['commandB2', 'arg1', 'arg2'], name: 'job B2'),

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -24,86 +24,136 @@ void main() {
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
   });
 
-  tearDown(() {});
-
-  group('Output Capture', () {
-    test('startWorkers works', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, 0, 'output1', ''),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      await for (final WorkerJob _ in processPool.startWorkers(jobs)) {}
-      fakeProcessManager.verifyCalls(calls.keys);
-    });
-    test('runToCompletion works', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, 0, 'output1', ''),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
+  test('startWorkers works', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, 0, 'output1', ''),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    await for (final WorkerJob _ in processPool.startWorkers(jobs)) {}
+    fakeProcessManager.verifyCalls(calls.keys);
+  });
+  test('runToCompletion works', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, 0, 'output1', ''),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    await processPool.runToCompletion(jobs);
+    fakeProcessManager.verifyCalls(calls.keys);
+  });
+  test('failed tests report results', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.first.result.exitCode, equals(-1));
+    expect(completed.first.result.stdout, equals('output1'));
+    expect(completed.first.result.stderr, equals('stderr1'));
+    expect(completed.first.result.output, equals('output1stderr1'));
+  });
+  test('failed tests throw when failOk is false', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1', failOk: false),
+    ];
+    expect(() async {
       await processPool.runToCompletion(jobs);
-      fakeProcessManager.verifyCalls(calls.keys);
-    });
-    test('failed tests report results', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
+    }, throwsException);
+  });
+  test('Commands that throw exceptions report results', () async {
+    fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processPool = ProcessPool(processRunner: processRunner, printReport: null);
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.first.result, equals(ProcessRunnerResult.failed));
+    expect(completed.first.exception, isNotNull);
+  });
+
+  test('Commands in task groups run in order, but parallel with other groups', () async {
+    fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processPool = ProcessPool(processRunner: processRunner, printReport: null);
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['commandA1', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB1', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandA2', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB2', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandA3', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB3', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<Job> jobs = <Job>[
+      WorkerTaskGroup(
+        <WorkerJob>[
+          WorkerJob(<String>['commandA1', 'arg1', 'arg2'], name: 'job A1'),
+          WorkerJob(<String>['commandA2', 'arg1', 'arg2'], name: 'job A2'),
+          WorkerJob(<String>['commandA3', 'arg1', 'arg2'], name: 'job A3'),
         ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
-      expect(completed.first.result.exitCode, equals(-1));
-      expect(completed.first.result.stdout, equals('output1'));
-      expect(completed.first.result.stderr, equals('stderr1'));
-      expect(completed.first.result.output, equals('output1stderr1'));
-    });
-    test('failed tests throw when failOk is false', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
+      ),
+      WorkerTaskGroup(
+        <WorkerJob>[
+          WorkerJob(<String>['commandB1', 'arg1', 'arg2'], name: 'job B1'),
+          WorkerJob(<String>['commandB2', 'arg1', 'arg2'], name: 'job B2'),
+          WorkerJob(<String>['commandB3', 'arg1', 'arg2'], name: 'job B3'),
         ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1', failOk: false),
-      ];
-      expect(() async {
-        await processPool.runToCompletion(jobs);
-      }, throwsException);
-    });
-    test('Commands that throw exceptions report results', () async {
-      fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
-      processRunner = ProcessRunner(processManager: fakeProcessManager);
-      processPool = ProcessPool(processRunner: processRunner, printReport: null);
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
-      expect(completed.first.result, equals(ProcessRunnerResult.failed));
-      expect(completed.first.exception, isNotNull);
-    });
+      ),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.length, equals(6));
+    // Either group A or B can come first, but the individual group tasks should
+    // be in order.
+    expect(
+      <String>[completed[0].name, completed[1].name],
+      unorderedEquals(<String>['job A1', 'job B1']),
+    );
+    expect(
+      <String>[completed[2].name, completed[3].name],
+      unorderedEquals(<String>['job A2', 'job B2']),
+    );
+    expect(
+      <String>[completed[4].name, completed[5].name],
+      unorderedEquals(<String>['job A3', 'job B3']),
+    );
   });
 }


### PR DESCRIPTION
## Description

This adds a new type of job, a `WorkerTaskGroup`, which allows you to define a group of tasks that run in order, but run in parallel with other groups. This lets you define tasks that are dependent upon each other to control how parallel things are.

## Tests
 - Added a test to make sure tasks are executed in the correct order.