### PR TITLE
Add `WorkerJobGroup` for serial tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log for `process_runner`
 
-## 5.0.0
+## 4.2.0
 
-* Added `WorkerTaskGroup` for running a group of dependent tasks in order.
-* Adds pending jobs to progress reporting callback API, causing a breaking change to the `ProcessPool` API.
+* Added `WorkerJobGroup` for running a group of dependent tasks in order.
+* Added the ability to have one job depend on another,
+so that order between jobs can be enforced.
 
 ## 4.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 4.2.0
 
-* Added `WorkerJobGroup` for running a group of dependent tasks in order.
-* Added the ability to have one job depend on another,
+* Adds `WorkerJobGroup` for running a group of dependent tasks in order.
+* Adds the ability to have one job depend on another,
 so that order between jobs can be enforced.
 
 ## 4.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log for `process_runner`
 
-## 4.1.5
+## 5.0.0
 
-* Added WorkerTaskGroup for running a group of dependent tasks in order.
+* Added `WorkerTaskGroup` for running a group of dependent tasks in order.
+* Adds pending jobs to progress reporting callback API, causing a breaking change to the `ProcessPool` API.
 
 ## 4.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for `process_runner`
 
+## 4.1.5
+
+* Added WorkerTaskGroup for running a group of dependent tasks in order.
+
 ## 4.1.4
 
 * Bump dependency version for `process`.
@@ -40,11 +44,11 @@
 
 ## 4.0.0-nullsafety.3
 
-* Rebase onto non-nullsafety version 3.1.1 to pick up those changes. 
+* Rebase onto non-nullsafety version 3.1.1 to pick up those changes.
 
 ## 4.0.0-nullsafety.2
 
-* Rebase onto non-nullsafety version 3.1.0 to pick up those changes. 
+* Rebase onto non-nullsafety version 3.1.0 to pick up those changes.
 
 ## 4.0.0-nullsafety.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -81,7 +81,6 @@ linter:
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
     - cast_nullable_to_non_nullable
-    - collection_methods_unrelated_type
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -81,6 +81,7 @@ linter:
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
     - cast_nullable_to_non_nullable
+    - collection_methods_unrelated_type
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204

--- a/example/main.dart
+++ b/example/main.dart
@@ -121,11 +121,9 @@ void stderrPrintReport(
   int completed,
   int inProgress,
   int pending,
-  int groupsPending,
   int failed,
 ) {
-  stderr.write(ProcessPool.defaultReportToString(
-      total, completed, inProgress, pending, groupsPending, failed));
+  stderr.write(ProcessPool.defaultReportToString(total, completed, inProgress, pending, failed));
 }
 
 Future<void> main(List<String> args) async {
@@ -311,7 +309,7 @@ Future<void> main(List<String> args) async {
             runInShell: runInShell,
             failOk: failOk,
           ));
-  final Iterable<Job> jobs = parallelJobs.cast<Job>().followedBy(groupedJobs);
+  final Iterable<DependentJob> jobs = parallelJobs.cast<DependentJob>().followedBy(groupedJobs);
   try {
     await for (final WorkerJob done in pool.startWorkers(jobs)) {
       if (printStdout) {

--- a/example/main.dart
+++ b/example/main.dart
@@ -123,7 +123,8 @@ void stderrPrintReport(
   int groupsPending,
   int failed,
 ) {
-  stderr.write(ProcessPool.defaultReportToString(total, completed, inProgress, pending, groupsPending, failed));
+  stderr.write(ProcessPool.defaultReportToString(
+      total, completed, inProgress, pending, groupsPending, failed));
 }
 
 Future<void> main(List<String> args) async {
@@ -286,20 +287,23 @@ Future<void> main(List<String> args) async {
   // Split each command entry into a list of strings, taking into account some
   // simple quoting and escaping.
   final List<List<List<String>>> splitCommands = commandGroups
-      .map<List<List<String>>>((List<String> group) => group.map<List<String>>(splitIntoArgs).toList())
+      .map<List<List<String>>>(
+          (List<String> group) => group.map<List<String>>(splitIntoArgs).toList())
       .toList();
 
   // If the numWorkers is set to null, then the ProcessPool will automatically
   // select the number of processes based on how many CPU cores the machine has.
   final int? numWorkers = int.tryParse(options[_kJobsOption] as String? ?? '');
-  final Directory workingDirectory = Directory((options[_kWorkingDirectoryOption] as String?) ?? '.');
+  final Directory workingDirectory =
+      Directory((options[_kWorkingDirectoryOption] as String?) ?? '.');
 
   final ProcessPool pool = ProcessPool(
     numWorkers: numWorkers,
     printReport: printReport ? stderrPrintReport : null,
   );
-  final Iterable<WorkerTaskGroup> jobs = splitCommands.map<WorkerTaskGroup>((List<List<String>> group) {
-    return WorkerTaskGroup(group
+  final Iterable<WorkerJobGroup> jobs =
+      splitCommands.map<WorkerJobGroup>((List<List<String>> group) {
+    return WorkerJobGroup(group
         .map<WorkerJob>((List<String> command) => WorkerJob(
               command,
               workingDirectory: workingDirectory,

--- a/example/main.dart
+++ b/example/main.dart
@@ -309,7 +309,7 @@ Future<void> main(List<String> args) async {
             runInShell: runInShell,
             failOk: failOk,
           ));
-  final Iterable<DependentJob> jobs = parallelJobs.cast<DependentJob>().followedBy(groupedJobs);
+  final Iterable<DependentJob> jobs = <DependentJob>[...parallelJobs, ...groupedJobs];
   try {
     await for (final WorkerJob done in pool.startWorkers(jobs)) {
       if (printStdout) {

--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -11,6 +11,13 @@ import 'package:process_runner/process_runner.dart';
 
 import 'process_runner.dart';
 
+/// A type of job that can depend on other jobs.
+///
+/// This is the base type of [WorkerJob] and [WorkerJobGroup], which can all
+/// depend on each other.
+///
+/// Jobs are not allowed to depend on themselves, or have a dependency depend on
+/// them, even indirectly.
 abstract class DependentJob {
   DependentJob({Iterable<DependentJob> dependsOn = const <DependentJob>{}})
       : _dependsOn = dependsOn.toSet();
@@ -165,6 +172,14 @@ class WorkerJob extends DependentJob {
   String toString() => name;
 }
 
+/// A job that groups other jobs.
+///
+/// Each worker job, except the first, are made to be dependent upon the
+/// previous worker job.
+///
+/// This group job is automatically dependent upon all of the [workers] it manages.
+///
+/// It can manage other groups, or individual [WorkerJob]s.
 class WorkerJobGroup extends DependentJob {
   WorkerJobGroup(Iterable<DependentJob> workers,
       {Iterable<DependentJob>? dependsOn, this.name = 'Group'})
@@ -181,7 +196,7 @@ class WorkerJobGroup extends DependentJob {
   @override
   final String name;
 
-  /// The workers that will run in order because They depend on each other.
+  /// The workers that will run in order because they depend on each other.
   final List<DependentJob> workers;
 
   @override

--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -16,8 +16,9 @@ import 'process_runner.dart';
 /// This is the base type of [WorkerJob] and [WorkerJobGroup], which can all
 /// depend on each other.
 ///
-/// Jobs are not allowed to depend on themselves, or have a dependency depend on
-/// them, even indirectly.
+/// Jobs are not allowed to have a dependency cycle, meaning that they can't
+/// depend on themselves, directly or indirectly. Will throw a
+/// [ProcessRunnerException] if a cycle is detected.
 abstract class DependentJob {
   DependentJob({Iterable<DependentJob> dependsOn = const <DependentJob>{}})
       : _dependsOn = dependsOn.toSet();
@@ -335,7 +336,12 @@ class ProcessPool {
       return;
     }
     printReport?.call(
-        totalJobs, _completedJobs.length, _inProgressJobs, _pendingJobs.length, _failedJobs.length);
+      totalJobs,
+      _completedJobs.length,
+      _inProgressJobs,
+      _pendingJobs.length,
+      _failedJobs.length,
+    );
   }
 
   static String defaultReportToString(

--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -410,14 +410,12 @@ class ProcessPool {
         await Future<void>.delayed(const Duration(milliseconds: 10));
         continue;
       }
-      if (newJob is! WorkerJob) {
+      if (newJob is WorkerJob) {
         // Just finish up any groups immediately now that all of their workers
         // are done. We keep them until now just in case a job depends on a
         // group. Don't yield these jobs either, since we don't want groups in
         // the output, just completed WorkerJobs.
-        if (newJob is WorkerJobGroup) {
-          _completedJobs.add(newJob);
-        }
+        _completedJobs.add(newJob);
         continue;
       }
       _inProgressJobs++;

--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -135,7 +135,8 @@ class WorkerJobGroup extends DependentJob {
     this.workers, {
     this.name = '<unknown>',
     bool setDependencies = true,
-  }) : assert(workers.isNotEmpty) {
+  })  : dependsOn = workers.toSet(),
+        assert(workers.isNotEmpty) {
     // Make sure they run in series.
     if (setDependencies) {
       for (int i = 1; i < workers.length; i++) {
@@ -147,12 +148,11 @@ class WorkerJobGroup extends DependentJob {
   @override
   final String name;
 
-  // The workers that will run in order because
-  // They depend on each other.
+  /// The workers that will run in order because They depend on each other.
   final List<DependentJob> workers;
 
   @override
-  Set<DependentJob> get dependsOn => workers.toSet();
+  final Set<DependentJob> dependsOn;
 
   @override
   void addToQueue(List<DependentJob> jobs) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: process_runner
 description: A process invocation abstraction for Dart that manages a multi-process queue.
-version: 5.0.0
+version: 4.2.0
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,11 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.5
+description: A process invocation abstraction for Dart that manages a multi-process queue.
+version: 5.0.0
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
-description: A process invocation abstraction for Dart that manages a multi-process queue.
 homepage: https://github.com/google/process_runner
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,8 +3,11 @@
 # found in the LICENSE file.
 
 name: process_runner
-version: 4.1.4
-description: A process invocation astraction for Dart that manages a multiprocess queue.
+version: 4.1.5
+repository: https://github.com/google/process_runner
+issue_tracker: https://github.com/google/process_runner/issues
+documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
+description: A process invocation abstraction for Dart that manages a multi-process queue.
 homepage: https://github.com/google/process_runner
 
 dependencies:

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -25,7 +25,8 @@ void main() {
   });
 
   test('startWorkers works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -38,7 +39,8 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('runToCompletion works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -51,7 +53,8 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('failed tests report results', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -67,7 +70,8 @@ void main() {
     expect(completed.first.result.output, equals('output1stderr1'));
   });
   test('failed tests throw when failOk is false', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -84,7 +88,8 @@ void main() {
     fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -102,7 +107,8 @@ void main() {
     fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
+        <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['commandA1', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -124,14 +130,14 @@ void main() {
     };
     fakeProcessManager.fakeResults = calls;
     final List<Job> jobs = <Job>[
-      WorkerTaskGroup(
+      WorkerJobGroup(
         <WorkerJob>[
           WorkerJob(<String>['commandA1', 'arg1', 'arg2'], name: 'job A1'),
           WorkerJob(<String>['commandA2', 'arg1', 'arg2'], name: 'job A2'),
           WorkerJob(<String>['commandA3', 'arg1', 'arg2'], name: 'job A3'),
         ],
       ),
-      WorkerTaskGroup(
+      WorkerJobGroup(
         <WorkerJob>[
           WorkerJob(<String>['commandB1', 'arg1', 'arg2'], name: 'job B1'),
           WorkerJob(<String>['commandB2', 'arg1', 'arg2'], name: 'job B2'),

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -24,86 +24,136 @@ void main() {
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
   });
 
-  tearDown(() {});
-
-  group('Output Capture', () {
-    test('startWorkers works', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, 0, 'output1', ''),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      await for (final WorkerJob _ in processPool.startWorkers(jobs)) {}
-      fakeProcessManager.verifyCalls(calls.keys);
-    });
-    test('runToCompletion works', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, 0, 'output1', ''),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
+  test('startWorkers works', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, 0, 'output1', ''),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    await for (final WorkerJob _ in processPool.startWorkers(jobs)) {}
+    fakeProcessManager.verifyCalls(calls.keys);
+  });
+  test('runToCompletion works', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, 0, 'output1', ''),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    await processPool.runToCompletion(jobs);
+    fakeProcessManager.verifyCalls(calls.keys);
+  });
+  test('failed tests report results', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.first.result.exitCode, equals(-1));
+    expect(completed.first.result.stdout, equals('output1'));
+    expect(completed.first.result.stderr, equals('stderr1'));
+    expect(completed.first.result.output, equals('output1stderr1'));
+  });
+  test('failed tests throw when failOk is false', () async {
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1', failOk: false),
+    ];
+    expect(() async {
       await processPool.runToCompletion(jobs);
-      fakeProcessManager.verifyCalls(calls.keys);
-    });
-    test('failed tests report results', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
+    }, throwsException);
+  });
+  test('Commands that throw exceptions report results', () async {
+    fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processPool = ProcessPool(processRunner: processRunner, printReport: null);
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<WorkerJob> jobs = <WorkerJob>[
+      WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.first.result, equals(ProcessRunnerResult.failed));
+    expect(completed.first.exception, isNotNull);
+  });
+
+  test('Commands in task groups run in order, but parallel with other groups', () async {
+    fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+    processRunner = ProcessRunner(processManager: fakeProcessManager);
+    processPool = ProcessPool(processRunner: processRunner, printReport: null);
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
+      FakeInvocationRecord(<String>['commandA1', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB1', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandA2', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB2', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandA3', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+      FakeInvocationRecord(<String>['commandB3', 'arg1', 'arg2'], testPath): <ProcessResult>[
+        ProcessResult(0, -1, 'output1', 'stderr1'),
+      ],
+    };
+    fakeProcessManager.fakeResults = calls;
+    final List<Job> jobs = <Job>[
+      WorkerTaskGroup(
+        <WorkerJob>[
+          WorkerJob(<String>['commandA1', 'arg1', 'arg2'], name: 'job A1'),
+          WorkerJob(<String>['commandA2', 'arg1', 'arg2'], name: 'job A2'),
+          WorkerJob(<String>['commandA3', 'arg1', 'arg2'], name: 'job A3'),
         ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
-      expect(completed.first.result.exitCode, equals(-1));
-      expect(completed.first.result.stdout, equals('output1'));
-      expect(completed.first.result.stderr, equals('stderr1'));
-      expect(completed.first.result.output, equals('output1stderr1'));
-    });
-    test('failed tests throw when failOk is false', () async {
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
+      ),
+      WorkerTaskGroup(
+        <WorkerJob>[
+          WorkerJob(<String>['commandB1', 'arg1', 'arg2'], name: 'job B1'),
+          WorkerJob(<String>['commandB2', 'arg1', 'arg2'], name: 'job B2'),
+          WorkerJob(<String>['commandB3', 'arg1', 'arg2'], name: 'job B3'),
         ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1', failOk: false),
-      ];
-      expect(() async {
-        await processPool.runToCompletion(jobs);
-      }, throwsException);
-    });
-    test('Commands that throw exceptions report results', () async {
-      fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
-      processRunner = ProcessRunner(processManager: fakeProcessManager);
-      processPool = ProcessPool(processRunner: processRunner, printReport: null);
-      final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-          <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
-          ProcessResult(0, -1, 'output1', 'stderr1'),
-        ],
-      };
-      fakeProcessManager.fakeResults = calls;
-      final List<WorkerJob> jobs = <WorkerJob>[
-        WorkerJob(<String>['command', 'arg1', 'arg2'], name: 'job 1'),
-      ];
-      final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
-      expect(completed.first.result, equals(ProcessRunnerResult.failed));
-      expect(completed.first.exception, isNotNull);
-    });
+      ),
+    ];
+    final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
+    expect(completed.length, equals(6));
+    // Either group A or B can come first, but the individual group tasks should
+    // be in order.
+    expect(
+      <String>[completed[0].name, completed[1].name],
+      unorderedEquals(<String>['job A1', 'job B1']),
+    );
+    expect(
+      <String>[completed[2].name, completed[3].name],
+      unorderedEquals(<String>['job A2', 'job B2']),
+    );
+    expect(
+      <String>[completed[4].name, completed[5].name],
+      unorderedEquals(<String>['job A3', 'job B3']),
+    );
   });
 }

--- a/test/src/process_pool_test.dart
+++ b/test/src/process_pool_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:process_runner/process_runner.dart';
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 import 'fake_process_manager.dart';
@@ -25,8 +26,7 @@ void main() {
   });
 
   test('startWorkers works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -39,8 +39,7 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('runToCompletion works', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, 0, 'output1', ''),
       ],
@@ -53,8 +52,7 @@ void main() {
     fakeProcessManager.verifyCalls(calls.keys);
   });
   test('failed tests report results', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -70,8 +68,7 @@ void main() {
     expect(completed.first.result.output, equals('output1stderr1'));
   });
   test('failed tests throw when failOk is false', () async {
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -88,8 +85,7 @@ void main() {
     fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath): <ProcessResult>[
         ProcessResult(0, -1, 'output1', 'stderr1'),
       ],
@@ -104,38 +100,38 @@ void main() {
   });
 
   test('Commands in task groups run in order, but parallel with other groups', () async {
-    fakeProcessManager = FakeProcessManager((String value) {}, commandsThrow: true);
+    fakeProcessManager = FakeProcessManager((String value) {});
     processRunner = ProcessRunner(processManager: fakeProcessManager);
     processPool = ProcessPool(processRunner: processRunner, printReport: null);
-    final Map<FakeInvocationRecord, List<ProcessResult>> calls =
-        <FakeInvocationRecord, List<ProcessResult>>{
+    final Map<FakeInvocationRecord, List<ProcessResult>> calls = <FakeInvocationRecord, List<ProcessResult>>{
       FakeInvocationRecord(<String>['commandA1', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, 0, 'outputA1', 'stderrA1'),
       ],
       FakeInvocationRecord(<String>['commandB1', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, 0, 'outputB1', 'stderrB1'),
       ],
       FakeInvocationRecord(<String>['commandA2', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, 0, 'outputA2', 'stderrA2'),
       ],
       FakeInvocationRecord(<String>['commandB2', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, -1, 'outputB2', 'stderrB2'),
       ],
       FakeInvocationRecord(<String>['commandA3', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, 0, 'outputA3', 'stderrA3'),
       ],
       FakeInvocationRecord(<String>['commandB3', 'arg1', 'arg2'], testPath): <ProcessResult>[
-        ProcessResult(0, -1, 'output1', 'stderr1'),
+        ProcessResult(0, 0, 'outputB3', 'stderrB3'),
       ],
     };
     fakeProcessManager.fakeResults = calls;
-    final List<Job> jobs = <Job>[
+    final List<WorkerJobGroup> jobs = <WorkerJobGroup>[
       WorkerJobGroup(
         <WorkerJob>[
           WorkerJob(<String>['commandA1', 'arg1', 'arg2'], name: 'job A1'),
           WorkerJob(<String>['commandA2', 'arg1', 'arg2'], name: 'job A2'),
           WorkerJob(<String>['commandA3', 'arg1', 'arg2'], name: 'job A3'),
         ],
+        name: 'Group A',
       ),
       WorkerJobGroup(
         <WorkerJob>[
@@ -143,10 +139,24 @@ void main() {
           WorkerJob(<String>['commandB2', 'arg1', 'arg2'], name: 'job B2'),
           WorkerJob(<String>['commandB3', 'arg1', 'arg2'], name: 'job B3'),
         ],
+        name: 'Group B',
       ),
     ];
     final List<WorkerJob> completed = await processPool.runToCompletion(jobs);
     expect(completed.length, equals(6));
+    // Command B2 failed with -1, so B3 should also fail.
+    expect(
+      completed.where((WorkerJob job) => job.result.exitCode != 0).map((WorkerJob job) => job.name),
+      unorderedEquals(<String>['job B2', 'job B3']),
+    );
+    expect(
+      completed.where((WorkerJob job) => job.exception == null).map((WorkerJob job) => job.name),
+      unorderedEquals(<String>['job A1', 'job B1', 'job A2', 'job A3']),
+    );
+    expect(
+      completed.where((WorkerJob job) => job.result.exitCode == 0).map((WorkerJob job) => job.name),
+      unorderedEquals(<String>['job B1', 'job A1', 'job A2', 'job A3']),
+    );
     // Either group A or B can come first, but the individual group tasks should
     // be in order.
     expect(


### PR DESCRIPTION
## Description

This adds a new type of job, a `WorkerJobGroup`, which allows you to define a group of tasks that run in order, but run in parallel with other groups. This lets you define tasks that are dependent upon each other to control how parallel things are.

Also allows individual `WorkerJob`s to depend on other jobs or `WorkerJobGroups`.

## Tests
 - Added a test to make sure tasks are executed in the correct order, and that no dependency loops are allowed.