### PR TITLE
Do some cleanup and add tests.

### DIFF
--- a/.github/workflows/process_runner.yml
+++ b/.github/workflows/process_runner.yml
@@ -2,9 +2,9 @@ name: Process Package
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log for `process_runner`
 
+## 4.2.2
+
+- Refactoring the main `run` method in `ProcessRunner` into smaller, more
+  manageable private methods.
+- Enhancing `FakeProcessManager` to differentiate commands based on their
+  working directory and the `runInShell` parameter, and adding more
+  comprehensive tests for it.
+- Making the addition of dependencies in `ProcessPool` idempotent (do nothing if
+  the dependency already exists).
+- Updating the CI to track the main branch.
+- Adding a number of new tests to cover `stdin` handling, `runInShell` behavior,
+  and exception scenarios.
+
 ## 4.2.1
 
 - Updates analysis_options.yaml to modern lints, and updates formatting.

--- a/lib/src/process_pool.dart
+++ b/lib/src/process_pool.dart
@@ -59,7 +59,7 @@ abstract class DependentJob {
       throw ProcessRunnerException('A job cannot depend on itself');
     }
     if (_dependsOn.contains(job)) {
-      throw ProcessRunnerException('$job is already a dependency of $this');
+      return;
     }
     if (job._dependsOn.contains(this)) {
       throw ProcessRunnerException(
@@ -225,13 +225,16 @@ class WorkerJobGroup extends DependentJob {
   WorkerJobGroup(Iterable<DependentJob> jobs,
       {Iterable<DependentJob>? dependsOn, this.name = 'Group'})
       : assert(jobs.isNotEmpty),
-        jobs = <DependentJob>[...jobs],
+        jobs = jobs.toList(),
         super(dependsOn: <DependentJob>{
           ...jobs.toSet(),
           if (dependsOn != null) ...dependsOn
         }) {
     // Make sure they run in series, and they depend on anything that the group
     // depends on.
+    if (dependsOn != null) {
+      this.jobs.first.addDependencies(dependsOn);
+    }
     for (var i = 1; i < this.jobs.length; i++) {
       this.jobs[i].addDependency(this.jobs[i - 1]);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: process_runner
 description: A process invocation abstraction for Dart that manages a multi-process queue.
-version: 4.2.1
+version: 4.2.2
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
@@ -24,7 +24,7 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.5.2
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.14.0 <4.0.0"
 
 binaries:
   process_runner:

--- a/test/src/fake_process_manager_test.dart
+++ b/test/src/fake_process_manager_test.dart
@@ -5,24 +5,145 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:file/memory.dart';
+import 'package:process_runner/process_runner.dart';
 import 'package:process_runner/test/fake_process_manager.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
-  group('ArchivePublisher', () {
+  group('FakeProcessManager', () {
     final stdinCaptured = <String>[];
     void captureStdin(String item) {
       stdinCaptured.add(item);
     }
 
-    var processManager = FakeProcessManager(captureStdin);
+    late MemoryFileSystem fs;
+    late FakeProcessManager processManager;
+    late ProcessRunner processRunner;
 
     setUp(() async {
+      fs = MemoryFileSystem(
+          style: Platform.isWindows
+              ? FileSystemStyle.windows
+              : FileSystemStyle.posix);
       processManager = FakeProcessManager(captureStdin);
+      processRunner = ProcessRunner(
+          processManager: processManager,
+          defaultWorkingDirectory: fs.currentDirectory);
     });
 
-    tearDown(() async {});
+    tearDown(() async {
+      stdinCaptured.clear();
+    });
 
+    test('fakes processes', () async {
+      processManager.fakeResults = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(
+          <String>['command', 'arg1', 'arg2'],
+          workingDirectory: fs.currentDirectory.path,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+        FakeInvocationRecord(
+          <String>['command2', 'arg1', 'arg2'],
+          workingDirectory: fs.currentDirectory.path,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output2', ''),
+        ],
+      };
+      var result =
+          await processRunner.runProcess(<String>['command', 'arg1', 'arg2']);
+      expect(result.stdout, equals('output1'));
+      result =
+          await processRunner.runProcess(<String>['command2', 'arg1', 'arg2']);
+      expect(result.stdout, equals('output2'));
+      processManager.verifyCalls(<FakeInvocationRecord>[
+        FakeInvocationRecord(
+          <String>['command', 'arg1', 'arg2'],
+          workingDirectory: fs.currentDirectory.path,
+        ),
+        FakeInvocationRecord(
+          <String>['command2', 'arg1', 'arg2'],
+          workingDirectory: fs.currentDirectory.path,
+        ),
+      ]);
+    });
+    test('distinguishes commands by working directory', () async {
+      processManager.fakeResults = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: Directory('wd1').absolute.path,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: Directory('wd2').absolute.path,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output2', ''),
+        ],
+      };
+      var result = await processRunner.runProcess(
+        <String>['command', 'arg'],
+        workingDirectory: Directory('wd1'),
+      );
+      expect(result.stdout, equals('output1'));
+      result = await processRunner.runProcess(
+        <String>['command', 'arg'],
+        workingDirectory: Directory('wd2'),
+      );
+      expect(result.stdout, equals('output2'));
+      processManager.verifyCalls(<FakeInvocationRecord>[
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: Directory('wd1').absolute.path,
+        ),
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: Directory('wd2').absolute.path,
+        ),
+      ]);
+    });
+    test('distinguishes commands by runInShell', () async {
+      processManager.fakeResults = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: fs.currentDirectory.path,
+          runInShell: true,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: fs.currentDirectory.path,
+          runInShell: false,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output2', ''),
+        ],
+      };
+      var result = await processRunner.runProcess(
+        <String>['command', 'arg'],
+        runInShell: true,
+      );
+      expect(result.stdout, equals('output1'));
+      result = await processRunner.runProcess(
+        <String>['command', 'arg'],
+        runInShell: false,
+      );
+      expect(result.stdout, equals('output2'));
+      processManager.verifyCalls(<FakeInvocationRecord>[
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: fs.currentDirectory.path,
+          runInShell: true,
+        ),
+        FakeInvocationRecord(
+          <String>['command', 'arg'],
+          workingDirectory: fs.currentDirectory.path,
+          runInShell: false,
+        ),
+      ]);
+    });
     test('start works', () async {
       final calls = <FakeInvocationRecord, List<ProcessResult>>{
         FakeInvocationRecord(<String>['command', 'arg1', 'arg2']):
@@ -113,6 +234,30 @@ void main() {
         expect(stdinCaptured.last, equals(testInput));
       }
       processManager.verifyCalls(calls.keys.toList());
+    });
+
+    test('run throws when commandsThrow is true', () async {
+      processManager = FakeProcessManager(captureStdin, commandsThrow: true);
+      expect(
+        () async => await processManager.run(<String>['command']),
+        throwsA(isA<ProcessException>()),
+      );
+    });
+
+    test('runSync throws when commandsThrow is true', () async {
+      processManager = FakeProcessManager(captureStdin, commandsThrow: true);
+      expect(
+        () => processManager.runSync(<String>['command']),
+        throwsA(isA<ProcessException>()),
+      );
+    });
+
+    test('start throws when commandsThrow is true', () async {
+      processManager = FakeProcessManager(captureStdin, commandsThrow: true);
+      expect(
+        () async => await processManager.start(<String>['command']),
+        throwsA(isA<ProcessException>()),
+      );
     });
   });
 }

--- a/test/src/process_runner_test.dart
+++ b/test/src/process_runner_test.dart
@@ -9,12 +9,18 @@ import 'package:process_runner/test/fake_process_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var fakeProcessManager = FakeProcessManager((String value) {});
+  final stdinCaptured = <String>[];
+  void captureStdin(String item) {
+    stdinCaptured.add(item);
+  }
+
+  var fakeProcessManager = FakeProcessManager(captureStdin);
   var processRunner = ProcessRunner(processManager: fakeProcessManager);
   final testPath = Platform.isWindows ? r'C:\tmp\foo' : '/tmp/foo';
 
   setUp(() {
-    fakeProcessManager = FakeProcessManager((String value) {});
+    stdinCaptured.clear();
+    fakeProcessManager = FakeProcessManager(captureStdin);
     processRunner = ProcessRunner(
         processManager: fakeProcessManager,
         defaultWorkingDirectory: Directory(testPath));
@@ -25,8 +31,8 @@ void main() {
   group('Output Capture', () {
     test('runProcess works', () async {
       final calls = <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath):
-            <ProcessResult>[
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: testPath): <ProcessResult>[
           ProcessResult(0, 0, 'output1', ''),
         ],
       };
@@ -36,8 +42,8 @@ void main() {
     });
     test('runProcess returns correct output', () async {
       final calls = <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath):
-            <ProcessResult>[
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: testPath): <ProcessResult>[
           ProcessResult(0, 0, 'output1', 'stderr1'),
         ],
       };
@@ -51,8 +57,8 @@ void main() {
     });
     test('runProcess fails properly', () async {
       final calls = <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], ''):
-            <ProcessResult>[
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: ''): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };
@@ -63,8 +69,8 @@ void main() {
     });
     test('runProcess returns the failed results properly', () async {
       final calls = <FakeInvocationRecord, List<ProcessResult>>{
-        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'], testPath):
-            <ProcessResult>[
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: testPath): <ProcessResult>[
           ProcessResult(0, -1, 'output1', 'stderr1'),
         ],
       };
@@ -74,6 +80,58 @@ void main() {
       expect(result.stdout, equals('output1'));
       expect(result.stderr, equals('stderr1'));
       expect(result.output, equals('output1stderr1'));
+    });
+
+    test('runProcess with stdin works', () async {
+      final calls = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: testPath): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      final stdin = Stream<List<int>>.fromIterable(<List<int>>[
+        'input'.codeUnits,
+      ]);
+      final result = await processRunner.runProcess(
+        calls.keys.first.invocation,
+        stdin: stdin,
+      );
+      expect(result.stdout, equals('output1'));
+      expect(stdinCaptured, equals(<String>['input']));
+    });
+
+    test('runProcess with runInShell works', () async {
+      final calls = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(
+          <String>['command', 'arg1', 'arg2'],
+          workingDirectory: testPath,
+          runInShell: true,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      await processRunner.runProcess(
+        calls.keys.first.invocation,
+        runInShell: true,
+      );
+      fakeProcessManager.verifyCalls(calls.keys);
+    });
+
+    test('runProcess throws when process manager throws', () async {
+      fakeProcessManager.commandsThrow = true;
+      final calls = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(<String>['command', 'arg1', 'arg2'],
+            workingDirectory: testPath): <ProcessResult>[
+          ProcessResult(0, -1, 'output1', 'stderr1'),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      await expectLater(
+        () => processRunner.runProcess(calls.keys.first.invocation),
+        throwsA(isA<ProcessRunnerException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
# Description

- Refactoring the main `run` method in `ProcessRunner` into smaller, more manageable private methods.
- Enhancing `FakeProcessManager` to differentiate commands based on their working directory and the `runInShell` parameter, and adding more comprehensive tests for it.
- Making the addition of dependencies in `ProcessPool` idempotent (do nothing if the dependency already exists).
- Updating the CI to track the main branch.
- Adding a number of new tests to cover `stdin` handling, `runInShell` behavior, and exception scenarios.