### PR TITLE
Propagate `includeParentEnvironment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log for `process_runner`
 
+## 4.2.3
+
+- Propagate `includeParentEnvironment` to process manager (fixes
+  [#36](https://github.com/google/process_runner/issues/36))
+
 ## 4.2.2
 
 - Refactoring the main `run` method in `ProcessRunner` into smaller, more

--- a/lib/src/process_runner.dart
+++ b/lib/src/process_runner.dart
@@ -277,6 +277,7 @@ class ProcessRunner {
         commandLine,
         workingDirectory: workingDirectory.absolute.path,
         environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
         runInShell: runInShell,
         mode: startMode,
       );

--- a/lib/test/fake_process_manager.dart
+++ b/lib/test/fake_process_manager.dart
@@ -17,10 +17,12 @@ class FakeInvocationRecord {
     this.invocation, {
     this.workingDirectory,
     this.runInShell = false,
+    this.includeParentEnvironment = true,
   });
   final List<String> invocation;
   final String? workingDirectory;
   final bool runInShell;
+  final bool includeParentEnvironment;
 
   @override
   bool operator ==(Object other) {
@@ -39,6 +41,9 @@ class FakeInvocationRecord {
     if (other.runInShell != runInShell) {
       return false;
     }
+    if (other.includeParentEnvironment != includeParentEnvironment) {
+      return false;
+    }
     if (other.invocation.length != invocation.length) {
       return false;
     }
@@ -51,13 +56,14 @@ class FakeInvocationRecord {
   }
 
   @override
-  int get hashCode =>
-      Object.hashAll([workingDirectory, runInShell, ...invocation]);
+  int get hashCode => Object.hashAll(
+      [workingDirectory, runInShell, includeParentEnvironment, ...invocation]);
 
   @override
   String toString() {
     return 'FakeInvocationRecord(invocation: $invocation, '
-        'workingDirectory: $workingDirectory, runInShell: $runInShell)';
+        'workingDirectory: $workingDirectory, runInShell: $runInShell, '
+        'includeParentEnvironment: $includeParentEnvironment)';
   }
 }
 
@@ -123,11 +129,13 @@ class FakeProcessManager implements ProcessManager {
     List<String> invocation, {
     String? workingDirectory,
     bool runInShell = false,
+    bool includeParentEnvironment = true,
   }) async {
     final record = FakeInvocationRecord(
       invocation,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
     invocations.add(record);
     return Future<Process>.value(_popProcess(record));
@@ -137,11 +145,13 @@ class FakeProcessManager implements ProcessManager {
     List<String> invocation, {
     String? workingDirectory,
     bool runInShell = false,
+    bool includeParentEnvironment = true,
   }) {
     final record = FakeInvocationRecord(
       invocation,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
     invocations.add(record);
     return _popResult(record);
@@ -151,11 +161,13 @@ class FakeProcessManager implements ProcessManager {
     List<String> invocation, {
     String? workingDirectory,
     bool runInShell = false,
+    bool includeParentEnvironment = true,
   }) async {
     final record = FakeInvocationRecord(
       invocation,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
     invocations.add(record);
     return Future<ProcessResult>.value(_popResult(record));
@@ -188,6 +200,7 @@ class FakeProcessManager implements ProcessManager {
       command as List<String>,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
   }
 
@@ -208,6 +221,7 @@ class FakeProcessManager implements ProcessManager {
       command as List<String>,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
   }
 
@@ -227,6 +241,7 @@ class FakeProcessManager implements ProcessManager {
       command as List<String>,
       workingDirectory: workingDirectory,
       runInShell: runInShell,
+      includeParentEnvironment: includeParentEnvironment,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: process_runner
 description: A process invocation abstraction for Dart that manages a multi-process queue.
-version: 4.2.2
+version: 4.2.3
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md

--- a/test/src/process_runner_test.dart
+++ b/test/src/process_runner_test.dart
@@ -119,6 +119,28 @@ void main() {
       fakeProcessManager.verifyCalls(calls.keys);
     });
 
+    test('runProcess passes includeParentEnvironment to manager', () async {
+      processRunner = ProcessRunner(
+        processManager: fakeProcessManager,
+        defaultWorkingDirectory: Directory(testPath),
+        includeParentEnvironment: false,
+      );
+      final calls = <FakeInvocationRecord, List<ProcessResult>>{
+        FakeInvocationRecord(
+          <String>['command', 'arg1', 'arg2'],
+          workingDirectory: testPath,
+          includeParentEnvironment: false,
+        ): <ProcessResult>[
+          ProcessResult(0, 0, 'output1', ''),
+        ],
+      };
+      fakeProcessManager.fakeResults = calls;
+      await processRunner.runProcess(
+        <String>['command', 'arg1', 'arg2'],
+      );
+      fakeProcessManager.verifyCalls(calls.keys);
+    });
+
     test('runProcess throws when process manager throws', () async {
       fakeProcessManager.commandsThrow = true;
       final calls = <FakeInvocationRecord, List<ProcessResult>>{


### PR DESCRIPTION
Propagate `includeParentEnvironment` properly to process runner.