### PR TITLE
Reduce the test dependency to 1.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log for `process_runner`
 
+## 4.2.4
+
+- Downgrades the test dependency to 1.26.2 to make it compatible with Flutter
+  stable (3.35.7).
+
 ## 4.2.3
 
 - Propagate `includeParentEnvironment` to process manager (fixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: process_runner
 description: A process invocation abstraction for Dart that manages a multi-process queue.
-version: 4.2.3
+version: 4.2.4
 repository: https://github.com/google/process_runner
 issue_tracker: https://github.com/google/process_runner/issues
 documentation: https://github.com/google/process_runner/blob/master/process_runner/README.md
@@ -18,7 +18,7 @@ dependencies:
   path: ^1.8.0
   platform: ^3.1.0
   process: ^5.0.1
-  test: ^1.26.3
+  test: ^1.26.2
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.5.2


### PR DESCRIPTION
This reduces the `test` dependency to 1.26.2 so that it is compatible with the current Flutter stable release (3.35.7).